### PR TITLE
Add tests for CreateEditorWorkerRpc

### DIFF
--- a/packages/debug-worker/test/CreateEditorWorkerRpc.test.ts
+++ b/packages/debug-worker/test/CreateEditorWorkerRpc.test.ts
@@ -1,0 +1,27 @@
+import { createEditorWorkerRpc } from "../../src/parts/CreateEditorWorkerRpc/CreateEditorWorkerRpc";
+
+// Mock GetPortTuple to provide a valid MessageChannel
+jest.mock("../../src/parts/GetPortTuple/GetPortTuple", () => {
+  const { MessageChannel } = require('worker_threads');
+  return {
+    getPortTuple: () => {
+      const { port1, port2 } = new MessageChannel();
+      return { port1, port2 };
+    }
+  };
+});
+
+// Mock sendMessagePortToEditorWorker to simulate sending the port
+jest.mock("../../src/parts/SendMessagePortToEditorWorker/SendMessagePortToEditorWorker", () => ({
+  sendMessagePortToEditorWorker: async (port) => Promise.resolve()
+}));
+
+
+describe("createEditorWorkerRpc", () => {
+  it("should create an rpc instance", async () => {
+    const rpc = await createEditorWorkerRpc();
+    expect(rpc).toBeDefined();
+    expect(rpc).toHaveProperty('commandMap');
+  });
+});
+


### PR DESCRIPTION
Add a test for `createEditorWorkerRpc` to verify it creates a valid RPC instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8508e29-4cd4-4d39-bb0f-eb3e3a2e2b51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e8508e29-4cd4-4d39-bb0f-eb3e3a2e2b51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

